### PR TITLE
Use cursor offset and gt/lt for fullcount calculation

### DIFF
--- a/src/relay.js
+++ b/src/relay.js
@@ -310,6 +310,17 @@ export function createConnectionResolver({
           where: argsToWhere(args)
         }, args, context, info));
 
+        if (args.orderBy) {
+          const startIndex = Number(cursor.index);
+
+          if (startIndex >= 0) options.offset = startIndex + 1;
+        } else {
+          const operator = args.after ?
+            seqMajVer <= 3 ? '$gt' : Sequelize.Op.gt :
+            seqMajVer <= 3 ? '$lt' : Sequelize.Op.lt;
+          options.where[target.primaryKeyAttribute] = { [operator]: cursor.id };
+        }
+
         if (target.count) {
           if (target.associationType) {
             fullCount = await target.count(source, options);


### PR DESCRIPTION
This copy-pastes this same logic that we use when finding records to calculate `fullCount` correctly. Fixes a bug that we've been seeing where since `fullCount` doesn't decrease when paginating, the library always thinks that there is a next page.