### PR TITLE
Access arguments safely

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jonmagic-graphql-sequelize",
-  "version": "9.3.4-hack03",
+  "version": "9.3.4-hack04",
   "description": "GraphQL & Relay for MySQL & Postgres via Sequelize",
   "main": "lib/index.js",
   "options": {

--- a/src/simplifyAST.js
+++ b/src/simplifyAST.js
@@ -102,7 +102,7 @@ module.exports = function simplifyAST(ast, info, parent) {
       simpleAST.fields[key].key = name;
     }
 
-    simpleAST.fields[key].args = selection.arguments.reduce(function (args, arg) {
+    simpleAST.fields[key].args = selection?.arguments?.reduce(function (args, arg) {
       args[arg.name.value] = simplifyValue(arg.value, info);
       return args;
     }, {});

--- a/test/unit/simplifyAST.test.js
+++ b/test/unit/simplifyAST.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-import {expect} from 'chai';
-import simplifyAST from '../../src/simplifyAST';
+const {expect} = require('chai');
+const simplifyAST = require( '../../src/simplifyAST');
 var parser = require('graphql/language/parser').parse // eslint-disable-line
   , parse = function (query) {
     return parser(query).definitions[0];
@@ -352,6 +352,31 @@ describe('simplifyAST', function () {
           fields: {
             firstName: {
               key: 'name',
+              args: {},
+              fields: {}
+            }
+          }
+        }
+      }
+    });
+  });
+
+  it('should handle null arguments', function () {
+    expect(simplifyAST(parse(`
+      {
+        user(id: null) {
+          name
+        }
+      }
+    `))).to.deep.equal({
+      args: {},
+      fields: {
+        user: {
+          args: {
+            id: undefined
+          },
+          fields: {
+            name: {
               args: {},
               fields: {}
             }


### PR DESCRIPTION
While updating to `graphql` v16.10, I started gettng errors on querying as `Cannot read properties of undefined (reading 'reduce')` and tracked down the issue to the `simplifyAST` function.  

Tested also with the original fork but the same issue remained. 